### PR TITLE
Addition of a time_probe.py helper file.

### DIFF
--- a/Pose_Estimation/Functions.py
+++ b/Pose_Estimation/Functions.py
@@ -482,10 +482,13 @@ def mix_right_left(df,index,player):
 
 def df_coordinates(df,centerd):
     tic('DF_COORDINATES')
+
+    tic('LOCALIZATION_PREPROC')
     df.sort_values(by='Frame',ascending=1,inplace=True)
     df.reset_index(inplace=True,drop=True)
     df['Batter_player']=df['Batter'].copy()
     df['Pitcher_player']=df['Pitcher'].copy()
+
     for player in ['Batter','Pitcher']:
         player2=player+'_player'
         center=centerd[player]
@@ -506,14 +509,19 @@ def df_coordinates(df,centerd):
 
         df[player2][0]=df[player][0][loc]
         globals()['old_array_%s'%player]=np.asarray(df[player][0][loc])
+    toc('LOCALIZATION_PREPROC')
 
+    tic('LOCALIZATION')
     for frame in df['Frame'][1:len(df)]:
         for player in ['Batter','Pitcher']:
             df,globals()['old_array_%s'%player]=player_localization(df,frame,player,globals()['old_array_%s'%player])
+    toc('LOCALIZATION')
 
+    tic('MIX_LR')
     for player in player_list:
         for index in index_list:
             df=mix_right_left(df,index,player)
+    toc('MIX_LR')
 
     tic('CONT_PITCHER')
     df=continuity(df,'Pitcher')

--- a/Pose_Estimation/config
+++ b/Pose_Estimation/config
@@ -15,12 +15,14 @@ starting_range = 0.8
 ending_range = 2
 scale_search = 0.5, 1, 1.5, 2
 thre1 = 0.1
-thre2 = 0.05 
-thre3 = 0.5 
+thre2 = 0.05
+thre3 = 0.5
 min_num = 4
 mid_num = 10
 crop_ratio = 2.5
 bbox_ratio = 0.25
+
+print_tictoc = 0
 
 [models]
 ## don't edit this part

--- a/Pose_Estimation/time_probe.py
+++ b/Pose_Estimation/time_probe.py
@@ -1,7 +1,10 @@
 import time
+from config_reader import config_reader
+param_, model_ = config_reader()
+
+TIME_PRINT = param_['print_tictoc'] is '1'
 
 TIME_PROBE_ID = 0
-TIME_PROBE_PREV = None
 TIME_STACK = []
 TEXT_PADDING = 24
 FIRST_STAMP = None
@@ -25,20 +28,26 @@ def time_printout(stamp, level=0):
     accounted_percentage = 0.0
     for child in stamp.children:
         elapsed_percentage = child.elapsed / stamp.elapsed* 100
-        print child.pretty(level, elapsed_percentage)
+        if TIME_PRINT: print child.pretty(level, elapsed_percentage)
         time_printout(child, level + 1)
         accounted_percentage += elapsed_percentage
     # TODO: percentage unaccounted for
     if len(stamp.children):
         tabbing = ''.join(level * ['   '])
-        print '| %s---(%.2f%% unaccounted)' % (tabbing, 100 - accounted_percentage)
+        if TIME_PRINT: print '| %s---(%.2f%% unaccounted)' % (tabbing, 100 - accounted_percentage)
 
 def time_summary():
-    print '| TICTOC RESULTS:'
-    print '|'
+    global FIRST_STAMP, PREV_STAMP, TIME_STACK
 
-    print FIRST_STAMP.pretty()
+    if TIME_PRINT: print '| TICTOC RESULTS:'
+    if TIME_PRINT: print '|'
+
+    if TIME_PRINT: print FIRST_STAMP.pretty()
     time_printout(FIRST_STAMP, 1)
+
+    FIRST_STAMP = None
+    PREV_STAMP = None
+    TIME_STACK = []
 
 def tic(label):
     global FIRST_STAMP, PREV_STAMP


### PR DESCRIPTION
Time-probe module can output a clean summary of time measurements within functions.
Enable printout by setting `print_tictoc` in config to 1.

(also wrapped remaining torch-cuda functions in a function to improve compatibility)